### PR TITLE
Check unidirectional state transition in useControlledState

### DIFF
--- a/apps/react-lib-demo/src/pages/use-controlled-state-demo/DemoBasic.tsx
+++ b/apps/react-lib-demo/src/pages/use-controlled-state-demo/DemoBasic.tsx
@@ -12,6 +12,10 @@ export function DemoBasic() {
     useState("제어된 입력");
   const [controlledCounterValue, setControlledCounterValue] = useState(5);
 
+  // 전환 테스트용 상태
+  const [isInputControlled, setIsInputControlled] = useState(true);
+  const [transitionTestValue, setTransitionTestValue] = useState("초기값");
+
   const resetAll = () => {
     setControlledInputValue("");
     setControlledCounterValue(0);
@@ -133,6 +137,65 @@ export function DemoBasic() {
         </Card>
       </Grid>
 
+      {/* 전환 테스트 섹션 */}
+      <Card mt="4">
+        <Flex direction="column" gap="4">
+          <Flex align="center" gap="2">
+            <Badge color="orange" variant="soft">
+              전환 테스트 (경고 발생)
+            </Badge>
+            <Text size="2" color="gray">
+              제어/비제어 전환 시 콘솔 경고 확인
+            </Text>
+          </Flex>
+
+          <Flex direction="column" gap="3">
+            <Flex align="center" gap="2">
+              <Button
+                size="2"
+                variant={isInputControlled ? "solid" : "outline"}
+                color="green"
+                onClick={() => setIsInputControlled(true)}
+              >
+                제어 모드
+              </Button>
+              <Button
+                size="2"
+                variant={!isInputControlled ? "solid" : "outline"}
+                color="blue"
+                onClick={() => setIsInputControlled(false)}
+              >
+                비제어 모드
+              </Button>
+              <Text size="2" color="gray">
+                현재: {isInputControlled ? "제어" : "비제어"}
+              </Text>
+            </Flex>
+
+            <Box>
+              <DemoInput
+                placeholder="모드를 전환해보세요 (콘솔 확인)"
+                value={isInputControlled ? transitionTestValue : undefined}
+                onChange={isInputControlled ? setTransitionTestValue : undefined}
+                defaultValue="기본값"
+              />
+              <Text size="1" color="gray" mt="1" as="div">
+                {isInputControlled
+                  ? `현재 값: "${transitionTestValue}"`
+                  : "부모는 값을 모릅니다 (내부에서만 관리)"}
+              </Text>
+            </Box>
+          </Flex>
+
+          <Box p="2" className="bg-orange-50 rounded">
+            <Text size="1" color="orange">
+              ⚠️ 모드를 전환하면 개발자 도구 콘솔에 경고가 표시됩니다.
+              실제 앱에서는 이런 전환을 피해야 합니다.
+            </Text>
+          </Box>
+        </Flex>
+      </Card>
+
       {/* 설명 */}
       <Card mt="4">
         <Flex direction="column" gap="3">
@@ -157,6 +220,14 @@ export function DemoBasic() {
             <Text size="2">
               3. <Text weight="medium">useControlledState</Text>를 사용하면
               동일한 컴포넌트로 두 패턴을 모두 지원할 수 있습니다.
+            </Text>
+            <Text size="2">
+              4.{" "}
+              <Text weight="medium" color="orange">
+                전환 테스트
+              </Text>
+              에서 모드를 바꾸면 양방향 전환 감지가 작동하는 것을 확인할 수
+              있습니다.
             </Text>
           </Flex>
         </Flex>

--- a/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
@@ -49,8 +49,11 @@ export const useControlledState = <T>(
   useEffectDev(() => {
     // 제어/비제어 전환 감지 (양방향)
     if (wasControlled !== undefined && wasControlled !== isControlled) {
+      const previousState = wasControlled ? "제어" : "비제어";
+      const currentState = isControlled ? "제어" : "비제어";
+      
       const warningMessages = [
-        `useControlledState: 컴포넌트가 ${wasControlled ? "제어" : "비제어"}에서 ${isControlled ? "제어" : "비제어"}로 전환되었습니다.`,
+        `useControlledState: 컴포넌트가 ${previousState}에서 ${currentState}로 전환되었습니다.`,
         "이는 예측 불가능한 동작을 야기할 수 있습니다.",
         "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
       ];

--- a/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
@@ -47,14 +47,26 @@ export const useControlledState = <T>(
 
   // 개발 환경에서 잘못된 사용 패턴 경고
   useEffectDev(() => {
-    // 제어/비제어 전환 감지 (양방향)
-    if (wasControlled !== undefined && wasControlled !== isControlled) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `useControlledState: 컴포넌트가 ${wasControlled ? "제어" : "비제어"}에서 ${isControlled ? "제어" : "비제어"}로 전환되었습니다. ` +
-          "이는 예측 불가능한 동작을 야기할 수 있습니다. " +
-          "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
-      );
+    // 초기 렌더링이 아닌 경우에만 전환 감지
+    if (wasControlled !== undefined) {
+      // 비제어 → 제어 전환 감지
+      if (wasControlled === false && isControlled === true) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `useControlledState: 컴포넌트가 비제어에서 제어로 전환되었습니다. ` +
+            "이는 예측 불가능한 동작을 야기할 수 있습니다. " +
+            "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
+        );
+      }
+      // 제어 → 비제어 전환 감지
+      if (wasControlled === true && isControlled === false) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `useControlledState: 컴포넌트가 제어에서 비제어로 전환되었습니다. ` +
+            "이는 예측 불가능한 동작을 야기할 수 있습니다. " +
+            "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
+        );
+      }
     }
   }, [isControlled, wasControlled]);
 

--- a/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
@@ -47,26 +47,14 @@ export const useControlledState = <T>(
 
   // 개발 환경에서 잘못된 사용 패턴 경고
   useEffectDev(() => {
-    // 초기 렌더링이 아닌 경우에만 전환 감지
-    if (wasControlled !== undefined) {
-      // 비제어 → 제어 전환 감지
-      if (wasControlled === false && isControlled === true) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `useControlledState: 컴포넌트가 비제어에서 제어로 전환되었습니다. ` +
-            "이는 예측 불가능한 동작을 야기할 수 있습니다. " +
-            "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
-        );
-      }
-      // 제어 → 비제어 전환 감지
-      if (wasControlled === true && isControlled === false) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `useControlledState: 컴포넌트가 제어에서 비제어로 전환되었습니다. ` +
-            "이는 예측 불가능한 동작을 야기할 수 있습니다. " +
-            "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
-        );
-      }
+    // 제어/비제어 전환 감지 (양방향)
+    if (wasControlled !== undefined && wasControlled !== isControlled) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `useControlledState: 컴포넌트가 ${wasControlled ? "제어" : "비제어"}에서 ${isControlled ? "제어" : "비제어"}로 전환되었습니다. ` +
+          "이는 예측 불가능한 동작을 야기할 수 있습니다. " +
+          "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
+      );
     }
   }, [isControlled, wasControlled]);
 

--- a/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
@@ -47,8 +47,8 @@ export const useControlledState = <T>(
 
   // 개발 환경에서 잘못된 사용 패턴 경고
   useEffectDev(() => {
-    // uncontrolled to controlled 감지
-    if (wasControlled === false && isControlled === true) {
+    // 제어/비제어 전환 감지 (양방향)
+    if (wasControlled !== undefined && wasControlled !== isControlled) {
       // eslint-disable-next-line no-console
       console.warn(
         `useControlledState: 컴포넌트가 ${wasControlled ? "제어" : "비제어"}에서 ${isControlled ? "제어" : "비제어"}로 전환되었습니다. ` +
@@ -56,7 +56,7 @@ export const useControlledState = <T>(
           "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
       );
     }
-  }, [isControlled]);
+  }, [isControlled, wasControlled]);
 
   // 현재 값 결정 (제어: 외부 value, 비제어: 내부 state)
   const currentValue = isControlled ? value : internalState;

--- a/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/react-lib/src/hooks/useControlledState/useControlledState.ts
@@ -49,12 +49,14 @@ export const useControlledState = <T>(
   useEffectDev(() => {
     // 제어/비제어 전환 감지 (양방향)
     if (wasControlled !== undefined && wasControlled !== isControlled) {
+      const warningMessages = [
+        `useControlledState: 컴포넌트가 ${wasControlled ? "제어" : "비제어"}에서 ${isControlled ? "제어" : "비제어"}로 전환되었습니다.`,
+        "이는 예측 불가능한 동작을 야기할 수 있습니다.",
+        "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
+      ];
+      
       // eslint-disable-next-line no-console
-      console.warn(
-        `useControlledState: 컴포넌트가 ${wasControlled ? "제어" : "비제어"}에서 ${isControlled ? "제어" : "비제어"}로 전환되었습니다. ` +
-          "이는 예측 불가능한 동작을 야기할 수 있습니다. " +
-          "컴포넌트는 생명주기 동안 일관되게 제어되거나 비제어되어야 합니다."
-      );
+      console.warn(warningMessages.join(" "));
     }
   }, [isControlled, wasControlled]);
 

--- a/packages/react-lib/src/hooks/useControlledState/useControlledState.type.ts
+++ b/packages/react-lib/src/hooks/useControlledState/useControlledState.type.ts
@@ -15,9 +15,9 @@ export type UseControlledStateProps<T> = {
    * });
    *
    * @example
-   * // ❌ 잘못된 사용 - 조건부 제어
+   * // ❌ 잘못된 사용 - 조건부 제어 (양방향 전환 모두 위험)
    * const [value, setValue] = useControlledState({
-   *   value: condition ? externalValue : undefined,  // 위험!
+   *   value: condition ? externalValue : undefined,  // 위험! 제어↔비제어 전환
    *   onChange: setExternalValue
    * });
    */


### PR DESCRIPTION
Update `useControlledState` to warn about both controlled-to-uncontrolled and uncontrolled-to-controlled transitions, as the previous implementation only detected one direction.

The original `useControlledState` hook's warning logic for state transitions only caught `uncontrolled -> controlled` changes. This PR updates the logic to detect and warn for *any* transition between controlled and uncontrolled states, ensuring more robust usage warnings. A demo page section and type comments were also updated to reflect this change.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5615473-e778-4170-992d-0a1089d44b20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5615473-e778-4170-992d-0a1089d44b20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

